### PR TITLE
fix JMeter server fails

### DIFF
--- a/template/template/azure/vm/setup.sh
+++ b/template/template/azure/vm/setup.sh
@@ -99,6 +99,10 @@ wget http://www-us.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSIO
 wget https://jmeter-plugins.org/files/packages/jpgc-casutg-${CUSTOM_PLUGIN_VERSION}.zip
 unzip -o jpgc-casutg-${CUSTOM_PLUGIN_VERSION}.zip -d ${JMETER_HOME}
 
+# Disable Rmi SSL option
+sed -i.bak -e "s/#server.rmi.ssl.disable=false/server.rmi.ssl.disable=true/" ${JMETER_HOME}/bin/jmeter.properties
+
+# Clean up
 
 sudo DEBIAN_FRONTEND=noninteractive rm -rf apache-jmeter-${JMETER_VERSION}.tgz \
             jpgc-casutg-${CUSTOM_PLUGIN_VERSION}.zip \

--- a/template/template/azure/vm/setupslave.sh
+++ b/template/template/azure/vm/setupslave.sh
@@ -99,7 +99,10 @@ wget http://www-us.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSIO
 wget https://jmeter-plugins.org/files/packages/jpgc-casutg-${CUSTOM_PLUGIN_VERSION}.zip
 unzip -o jpgc-casutg-${CUSTOM_PLUGIN_VERSION}.zip -d ${JMETER_HOME}
 
+# Disable Rmi SSL option
+sed -i.bak -e "s/#server.rmi.ssl.disable=false/server.rmi.ssl.disable=true/" ${JMETER_HOME}/bin/jmeter.properties
 
+# Clean up
 sudo DEBIAN_FRONTEND=noninteractive rm -rf apache-jmeter-${JMETER_VERSION}.tgz \
             jpgc-casutg-${CUSTOM_PLUGIN_VERSION}.zip \
 			${JMETER_HOME}/bin/examples \


### PR DESCRIPTION
This PR is for this issue. 
https://github.com/TsuyoshiUshio/volley/issues/45

I solve the issue by disabling SSL for Rmi. Since this Master/Server is on the same VNET. 
I modify the jmeter.properties for disable it. 

Other solution is generate rmi_keystore. It might be required if you use ACI as provider in near future. 